### PR TITLE
Add JSON output

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,11 @@
 
     <div id="settings">
       Point every x length
-      <input type="text" id="step_point"/>
+      <input type="text" id="step_point"/>, JSON like 
+      <select id="json_type">
+        <option value="tuples" selected>[ [x, y], [x, y] ]</option>
+        <option value="single_array">[ x, y, x, y ]</option>
+      </select>
       <button type="text" id="btn-apply">Apply</button>
       <button type="text" id="btn-text">Generate from text</button>
     </div>


### PR DESCRIPTION
I used your website and found it very good, but I missed some JSON output!

This commit has two changes:
- Place the JSON output on the website, with 2 types of JSON output, one \<map\> like (like `[x, y, x, y]` ), and another "tuple" like (like `[ [x, y], [x, y] ]`)
- If the user loads an SVG file, it always does it 10px away first, even if the user has changed this value, so I always update this value before starting the process of creating the points

Visual changes:
![image](https://github.com/Shinao/PathToPoints/assets/44689444/84d65070-7f48-494a-a847-ca78be0fb1d3)

![image](https://github.com/Shinao/PathToPoints/assets/44689444/ba5d923d-dcbe-415e-9585-260862d5988d)


The changes are very simple, I hope you merge these changes!
Congratulations on the project!